### PR TITLE
Fix: set `compiler.cppstd` in conan profile

### DIFF
--- a/.github/actions/configure_conan/action.yml
+++ b/.github/actions/configure_conan/action.yml
@@ -29,3 +29,4 @@ runs:
           echo 'compiler={{ compiler }}'                                                       >> ~/.conan2/profiles/default
           echo 'compiler.version={{ detect_api.default_compiler_version(compiler, version) }}' >> ~/.conan2/profiles/default
           echo 'compiler.libcxx=libstdc++11'                                                   >> ~/.conan2/profiles/default
+          echo 'compiler.cppstd={{ detect_api.default_cppstd(compiler, version) }}'            >> ~/.conan2/profiles/default


### PR DESCRIPTION
Apparently this is now required?