### PR TITLE
Derive the gcc target triple instead of hardcoding darwin24.

### DIFF
--- a/scripts/setup-macos-env.sh
+++ b/scripts/setup-macos-env.sh
@@ -46,24 +46,18 @@ export PATH="${OPENJDK_PREFIX}/bin:${PATH}"
 export CC="${GCC_PREFIX}/bin/gcc-${GCC_VERSION}"
 export CXX="${GCC_PREFIX}/bin/g++-${GCC_VERSION}"
 
-# gcc keeps its target libraries in a directory named after the target triple.
-# The triple carries the darwin version gcc was built for, so it changes with
-# every macOS major release (macOS 15 is darwin24, macOS 26 is darwin25).
-GCC_TARGET_TRIPLE="$("${CC}" -dumpmachine)"
-GCC_TARGET_LIB_DIR="${GCC_PREFIX}/lib/gcc/${GCC_VERSION}/gcc/${GCC_TARGET_TRIPLE}/${GCC_VERSION}"
-
-if [[ ! -d "${GCC_TARGET_LIB_DIR}" ]]; then
-    echo "Error: ${GCC_TARGET_LIB_DIR} missing, gcc@${GCC_VERSION} install is incomplete" >&2
-    return 1
-fi
-
 # aws-lc-sys requires __ARM_FEATURE_AES and __ARM_FEATURE_SHA2
 # which are only enabled when you pass this option
 # see https://developer.arm.com/documentation/101754/0624/armclang-Reference/armclang-Command-line-Options/-march
 export CFLAGS="-march=armv8-a+aes+sha2"
 
+# gcc keeps its target libraries in a directory named after the target triple.
+# The triple carries the darwin version gcc was built for, so it changes with
+# every macOS major release (macOS 15 is darwin24, macOS 26 is darwin25).
+GCC_TARGET_TRIPLE="$("${CC}" -dumpmachine)"
+
 # rustc needs to be able to find libgcc.a libgcc_s.dylib and libstdc++.a
-export RUSTFLAGS="-L${GCC_PREFIX}/lib/gcc/${GCC_VERSION} -L${GCC_TARGET_LIB_DIR}"
+export RUSTFLAGS="-L${GCC_PREFIX}/lib/gcc/${GCC_VERSION} -L${GCC_PREFIX}/lib/gcc/${GCC_VERSION}/gcc/${GCC_TARGET_TRIPLE}/${GCC_VERSION}"
 
 # Workaround for issue in aws-lc-sys jitter-entropy component
 # https://github.com/aws/aws-lc-rs/issues/1008

--- a/scripts/setup-macos-env.sh
+++ b/scripts/setup-macos-env.sh
@@ -46,13 +46,24 @@ export PATH="${OPENJDK_PREFIX}/bin:${PATH}"
 export CC="${GCC_PREFIX}/bin/gcc-${GCC_VERSION}"
 export CXX="${GCC_PREFIX}/bin/g++-${GCC_VERSION}"
 
+# gcc keeps its target libraries in a directory named after the target triple.
+# The triple carries the darwin version gcc was built for, so it changes with
+# every macOS major release (macOS 15 is darwin24, macOS 26 is darwin25).
+GCC_TARGET_TRIPLE="$("${CC}" -dumpmachine)"
+GCC_TARGET_LIB_DIR="${GCC_PREFIX}/lib/gcc/${GCC_VERSION}/gcc/${GCC_TARGET_TRIPLE}/${GCC_VERSION}"
+
+if [[ ! -d "${GCC_TARGET_LIB_DIR}" ]]; then
+    echo "Error: ${GCC_TARGET_LIB_DIR} missing, gcc@${GCC_VERSION} install is incomplete" >&2
+    return 1
+fi
+
 # aws-lc-sys requires __ARM_FEATURE_AES and __ARM_FEATURE_SHA2
 # which are only enabled when you pass this option
 # see https://developer.arm.com/documentation/101754/0624/armclang-Reference/armclang-Command-line-Options/-march
 export CFLAGS="-march=armv8-a+aes+sha2"
 
 # rustc needs to be able to find libgcc.a libgcc_s.dylib and libstdc++.a
-export RUSTFLAGS="-L${GCC_PREFIX}/lib/gcc/${GCC_VERSION} -L${GCC_PREFIX}/lib/gcc/${GCC_VERSION}/gcc/aarch64-apple-darwin24/${GCC_VERSION}"
+export RUSTFLAGS="-L${GCC_PREFIX}/lib/gcc/${GCC_VERSION} -L${GCC_TARGET_LIB_DIR}"
 
 # Workaround for issue in aws-lc-sys jitter-entropy component
 # https://github.com/aws/aws-lc-rs/issues/1008


### PR DESCRIPTION
The `-L` path for `libgcc.a` hardcoded `aarch64-apple-darwin24`. On macOS 26 the directory is `aarch64-apple-darwin25`, so the path did not exist and was dropped silently. The triple now comes from `gcc -dumpmachine`, with a check that the directory exists.

I encountered this on my mac that has darwin25