### PR TITLE
Restrict Renovate PR creation and rebasing to Sundays

### DIFF
--- a/dicegroup.json
+++ b/dicegroup.json
@@ -15,6 +15,8 @@
   ],
   "prHourlyLimit": 0,
   "rebaseWhen": "behind-base-branch",
+  "schedule": ["* * * * 0"],
+  "updateNotScheduled": false,
   "automerge": false,
   "enabledManagers": [
     "github-actions",

--- a/tentris.json
+++ b/tentris.json
@@ -15,6 +15,8 @@
   ],
   "prHourlyLimit": 0,
   "rebaseWhen": "behind-base-branch",
+  "schedule": ["* * * * 0"],
+  "updateNotScheduled": false,
   "automerge": false,
   "enabledManagers": [
     "github-actions",


### PR DESCRIPTION
The Renovate workflow still runs daily, but branch creation and updates for dice-group and tentris repos are now limited to Sunday (UTC) via schedule + updateNotScheduled.