### PR TITLE
Relax extractVersion for actions with non-semver tags

### DIFF
--- a/dicegroup.json
+++ b/dicegroup.json
@@ -61,6 +61,16 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchDepNames": [
+        "rui314/setup-mold",
+        "rlalik/setup-cpp-compiler"
+      ],
+      "extractVersion": "^v(?<version>\\d+(?:\\.\\d+){0,2})$"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch"

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,16 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchDepNames": [
+        "rui314/setup-mold",
+        "rlalik/setup-cpp-compiler"
+      ],
+      "extractVersion": "^v(?<version>\\d+(?:\\.\\d+){0,2})$"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch"

--- a/tentris.json
+++ b/tentris.json
@@ -61,6 +61,16 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchDepNames": [
+        "rui314/setup-mold",
+        "rlalik/setup-cpp-compiler"
+      ],
+      "extractVersion": "^v(?<version>\\d+(?:\\.\\d+){0,2})$"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch"


### PR DESCRIPTION
rui314/setup-mold and rlalik/setup-cpp-compiler don't publish full major.minor.patch tags, so the shared strict extractVersion regex never matched them, leaving noisy "no results that look like a version" INFO logs every run.