### PR TITLE
Set RENOVATE_CONFIG_FILE for the self-repo Renovate step

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,6 +41,7 @@ jobs:
         uses: renovatebot/github-action@v46.1.21
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_CONFIG_FILE: renovate.json
         with:
           token: ${{ secrets.RENOVATE_TOKEN_DICEGROUP }}
 


### PR DESCRIPTION
Without it, gitAuthor wasn't loaded into the global config in time for Renovate's startup check, triggering a spurious warning about the default renovate@whitesourcesoftware.com address that the other two steps (which do set RENOVATE_CONFIG_FILE) don't hit.